### PR TITLE
Added support for cross compiling this crate from linux host

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,6 @@ fn main() {
     } else if cfg!(target_os = "macos") {
         gcc::compile_library("libinfo.a", &["c/macos.c"]);
     } else if cfg!(target_os = "windows") {
-        println!("ran windows build...");
         gcc::compile_library("libinfo.a", &["c/windows.c"]);
         println!("cargo:rustc-flags=-l psapi");
     } else {

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,25 @@
 extern crate gcc;
 
+use std::env;
+
 fn main() {
     if cfg!(target_os = "linux") {
-        gcc::compile_library("libinfo.a", &["c/linux.c"]);
+        let key = "TARGET";
+		match env::var_os(key) {
+			Some(val) => {
+                let target = val.into_string().unwrap();
+                if target.contains("windows") {
+                    gcc::compile_library("libinfo.a", &["c/windows.c"]);
+                } else {
+                   gcc::compile_library("libinfo.a", &["c/linux.c"]); 
+                }
+            },
+			None => gcc::compile_library("libinfo.a", &["c/linux.c"]),
+		}
     } else if cfg!(target_os = "macos") {
         gcc::compile_library("libinfo.a", &["c/macos.c"]);
     } else if cfg!(target_os = "windows") {
+        println!("ran windows build...");
         gcc::compile_library("libinfo.a", &["c/windows.c"]);
         println!("cargo:rustc-flags=-l psapi");
     } else {

--- a/c/windows.c
+++ b/c/windows.c
@@ -77,10 +77,13 @@ LoadAvg get_loadavg(void) {
 
 unsigned long get_proc_total(void) {
 	DWORD aprocesses[MAXPROCESSES], cb_needed, cprocesses;
-
+#ifdef PSAPI_VERSION == 2
 	if (!K32EnumProcesses(aprocesses, sizeof(aprocesses), &cb_needed))
-		cprocesses = 0;
-	else
+#else
+	if (!EnumProcesses(aprocesses, sizeof(aprocesses), &cb_needed))
+    cprocesses = 0;
+#endif
+  else
 		cprocesses = cb_needed / sizeof(unsigned long);
 	return cprocesses;
 }

--- a/c/windows.c
+++ b/c/windows.c
@@ -78,7 +78,7 @@ LoadAvg get_loadavg(void) {
 unsigned long get_proc_total(void) {
 	DWORD aprocesses[MAXPROCESSES], cb_needed, cprocesses;
 
-	if (!EnumProcesses(aprocesses, sizeof(aprocesses), &cb_needed))
+	if (!K32EnumProcesses(aprocesses, sizeof(aprocesses), &cb_needed))
 		cprocesses = 0;
 	else
 		cprocesses = cb_needed / sizeof(unsigned long);


### PR DESCRIPTION
I ran into an issue while trying to use this library while cross compiling a rust program for windows and thought I should contribute back the small change to the build script I came up with to allow cross compiling...  I only added cross compiling targeting windows on linux hosts but I believe this logic would  also work on other build OSes for other targets.