### PR TITLE
Fix linux musl compilation

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -306,7 +306,8 @@ pub fn boottime() -> Result<timeval, Error> {
         tv_usec: 0
     };
 
-    if cfg!(target_os = "linux") {
+    #[cfg(target_os = "linux")]
+    {
         let mut s = String::new();
         File::open("/proc/uptime")?.read_to_string(&mut s)?;
         let secs = s.trim().split(' ')
@@ -315,7 +316,9 @@ pub fn boottime() -> Result<timeval, Error> {
             .collect::<Vec<f64>>();
         bt.tv_sec = secs[0] as libc::time_t;
         bt.tv_usec = secs[1] as libc::suseconds_t;
-    } else if cfg!(target_os = "macos") {
+    }
+    #[cfg(target_os = "macos")]
+    {
         let mut mib = [MAC_CTL_KERN, MAC_KERN_BOOTTIME];
         let mut size: libc::size_t = size_of_val(&bt) as libc::size_t;
         unsafe {

--- a/lib.rs
+++ b/lib.rs
@@ -13,7 +13,7 @@ use std::io::{self, Read};
 use std::fs::File;
 use std::os::raw::c_char;
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
 use libc::sysctl;
 use libc::timeval;
 use std::mem::size_of_val;
@@ -313,15 +313,15 @@ pub fn boottime() -> Result<timeval, Error> {
             .take(2)
             .map(|val| val.parse::<f64>().unwrap())
             .collect::<Vec<f64>>();
-        bt.tv_sec = secs[0]  as libc::time_t;
+        bt.tv_sec = secs[0] as libc::time_t;
         bt.tv_usec = secs[1] as libc::suseconds_t;
     } else if cfg!(target_os = "macos") {
         let mut mib = [MAC_CTL_KERN, MAC_KERN_BOOTTIME];
         let mut size: libc::size_t = size_of_val(&bt) as libc::size_t;
         unsafe {
             sysctl(&mut mib[0], 2,
-                    &mut bt as *mut timeval as *mut libc::c_void,
-                    &mut size, null_mut(), 0);
+                   &mut bt as *mut timeval as *mut libc::c_void,
+                   &mut size, null_mut(), 0);
         }
     }
 


### PR DESCRIPTION
`libc::sysctl` is not available on musl. This PR fixes compilation error.
