### PR TITLE
Initializing dtotal and dfree to avoid undefined behavior

### DIFF
--- a/c/linux.c
+++ b/c/linux.c
@@ -53,7 +53,7 @@ DiskInfo get_disk_info(void) {
 	char procline[1024];
 	char *mount, *device, *type, *mode, *other;
 	float thispct, max=0.0;
-	double dtotal, dfree;
+	double dtotal=0.0, dfree=0.0;
 	DiskInfo di;
 	
 	di.total = 0;


### PR DESCRIPTION
I ran into some undefined behavior where the library would return nonsensical values (usually capping at std::u64::MAX) because we'd would be treading into uninitialized memory since dtotal and dfree weren't initialized.