### PR TITLE
Include intrin.h to support 32bit windows arch

### DIFF
--- a/c/windows.c
+++ b/c/windows.c
@@ -3,8 +3,11 @@
 #include <string.h>
 #include <windows.h>
 #include <psapi.h>
+#include <intrin.h>
 
 #include "info.h"
+
+#pragma intrinsic(__rdtsc)
 
 #define LEN 20
 #define MAXPROCESSES 1024


### PR DESCRIPTION
`__rdtsc()` is supported on 32bit arch through the `intrin.h`