### PR TITLE
Fix windows test.

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -402,6 +402,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(windows))]
     pub fn test_boottime() {
         let bt = boottime().unwrap();
         println!("boottime(): {} {}", bt.tv_sec, bt.tv_usec);


### PR DESCRIPTION
Test on Windows native was failing with:

```
error[E0425]: cannot find function `boottime` in this scope
   --> lib.rs:415:18
    |
415 |         let bt = boottime().unwrap();
    |                  ^^^^^^^^ not found in this scope
```

This resolves it.