### PR TITLE
Don't suggest to use glob version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to `Cargo.toml`:
 
 ```
 [dependencies]
-sys-info = "*"
+sys-info = "0.5"
 ```
 
 and add this to crate root:


### PR DESCRIPTION
This could trip newcomers. It's basically impossible to guarantee "my code will work with all versions of this crate", because major versions tend to break the interface. See https://semver.org/ for more information.