### PR TITLE
fix boottime and proc_total issues on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Rust
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,45 @@
-name: Rust
+name: Test
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
-  build:
-
+  linux:
+    name: Linux ubuntu-latest
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Run example
+      run: cargo run --verbose --example info
+
+  windows:
+    name: Windows ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-10-LTSC-amd64-17763, windows-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run example
+      run: cargo run --verbose --example info
+
+  macos:
+    name: macOS-latest
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Get Rust
+      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup && sh ./rustup -y
+    - name: Build
+      run: source ~/.cargo/env; cargo build --verbose
+    - name: Run example
+      run: source ~/.cargo/env; cargo run --verbose --example info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose
-    - name: Run example
-      run: cargo run --verbose --example info
+    - name: Run test
+      run: cargo test --verbose
 
   windows:
     name: Windows ${{ matrix.os }}
@@ -29,8 +29,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose
-    - name: Run example
-      run: cargo run --verbose --example info
+    - name: Run test
+      run: cargo test --verbose
 
   macos:
     name: macOS-latest
@@ -41,5 +41,5 @@ jobs:
       run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup && sh ./rustup -y
     - name: Build
       run: source ~/.cargo/env; cargo build --verbose
-    - name: Run example
-      run: source ~/.cargo/env; cargo run --verbose --example info
+    - name: Run test
+      run: source ~/.cargo/env; cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 language: rust
 rust:
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 os:
   - linux
   - osx
-  - windows
 language: rust
 rust:
-  - stable
-  - beta
-  - nightly
+    -stable
+    -beta
+    -nightly
 cache: rust
 script:
   - cargo test --all --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ cc = "1"
 
 [dependencies]
 libc = "0.2.29"
+
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = ["sysinfoapi"]

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ and add this to crate root:
 extern crate sys_info;
 ```
 
+for more usage example, see the source file in test folder.

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -7,6 +7,7 @@ fn main() {
 
     println!("os: {} {}", os_type().unwrap(), os_release().unwrap());
     println!("cpu: {} cores, {} MHz", cpu_num().unwrap(), cpu_speed().unwrap());
+	//the proc total will work correctly on windows-amd64
     println!("proc total: {}", proc_total().unwrap());
     let load = loadavg().unwrap();
     println!("load: {} {} {}", load.one, load.five, load.fifteen);
@@ -17,6 +18,7 @@ fn main() {
     let disk = disk_info().unwrap();
     println!("disk: total {} KB, free {} KB", disk.total, disk.free);
     println!("hostname: {}", hostname().unwrap());
+	//now boottime works perfectly on windows-amd64 and linux-amd64
     let t = boottime().unwrap();
     println!("boottime {} sec, {} usec", t.tv_sec, t.tv_usec);
 


### PR DESCRIPTION
I  fixed the boottime and proc_total issues when i use sys_info which won't compile on windows, now it can work correctly on windows-10-amd64-17763(rust-1.49-msvc-stable ) and linux-amd64, thanks for your work.