### PR TITLE
patch to resolve x86_64-pc-windows-gnu warnings

### DIFF
--- a/c/windows.c
+++ b/c/windows.c
@@ -27,7 +27,7 @@ const char *get_os_release(void) {
 	osvi.dwOSVersionInfoSize = sizeof(osvi);
 
 	if (GetVersionEx(&osvi))
-		snprintf(s, LEN, "%d.%d.%d",
+		snprintf(s, LEN, "%ld.%ld.%ld",
 			 osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
 	else
 		strncpy(s, "unknown", LEN);
@@ -87,7 +87,7 @@ unsigned long get_proc_total(void) {
 
 MemInfo get_mem_info(void) {
 	MEMORYSTATUSEX stat;
-	DWORDLONG size;
+	/* DWORDLONG size; */
 	MemInfo mi;
 	
 	stat.dwLength = sizeof(stat);

--- a/lib.rs
+++ b/lib.rs
@@ -19,6 +19,7 @@ use libc::sysctl;
 use std::mem::size_of_val;
 #[cfg(target_os = "macos")]
 use std::ptr::null_mut;
+#[cfg(not(target_os = "windows"))]
 use libc::timeval;
 
 use std::collections::HashMap;


### PR DESCRIPTION
This patch is in response to a couple of gcc warnings that occur for the x86_64-pc-windows-gnu target.  

I built for x86_64-unknown-linux-musl and x86_64-apple-darwin as well and didn't see any issues, but haven't tested other targets.

```
cargo build --target x86_64-pc-windows-gnu
    Updating crates.io index
   Compiling libc v0.2.67
   Compiling cc v1.0.50
   Compiling sys-info v0.5.10 (/g/rich/w/sys-info-rs/sys-info-rs)
warning: c/windows.c: In function ‘get_os_release’:
warning: c/windows.c:30:22: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘DWORD {aka long unsigned int}’ [-Wformat=]
warning:    snprintf(s, LEN, "%d.%d.%d",
warning:                      ~^
warning:                      %ld
warning:      osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
warning:      ~~~~~~~~~~~~~~~~~~~
warning: c/windows.c:30:25: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘DWORD {aka long unsigned int}’ [-Wformat=]
warning:    snprintf(s, LEN, "%d.%d.%d",
warning:                         ~^
warning:                         %ld
warning:      osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
warning:                           ~~~~~~~~~~~~~~~~~~~
warning: c/windows.c:30:28: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘DWORD {aka long unsigned int}’ [-Wformat=]
warning:    snprintf(s, LEN, "%d.%d.%d",
warning:                            ~^
warning:                            %ld
warning:      osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
warning:                                                ~~~~~~~~~~~~~~~~~~
warning: c/windows.c: In function ‘get_mem_info’:
warning: c/windows.c:90:12: warning: unused variable ‘size’ [-Wunused-variable]
warning:   DWORDLONG size;
warning:             ^~~~
warning: unused import: `libc::timeval`
  --> lib.rs:22:5
   |
22 | use libc::timeval;
   |     ^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

    Finished dev [unoptimized + debuginfo] target(s) in 4.80s
```