### PR TITLE
improve kstat error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 0.6.1
+
+- Restore `Send` trait to `Error` for wrapping with `error-chain`
+
 ## 0.6.0
 
 - Support illumos and Solaris systems

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "sys-info"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Siyu Wang <FillZpp.pub@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/kstat.rs
+++ b/kstat.rs
@@ -123,7 +123,8 @@ mod wrapper {
                     stepping: false,
                 })
             } else {
-                Err("kstat_open(3KSTAT) failed".into())
+                let e = std::io::Error::last_os_error();
+                Err(format!("kstat_open(3KSTAT) failed: {}", e).into())
             }
         }
 

--- a/lib.rs
+++ b/lib.rs
@@ -104,7 +104,7 @@ pub enum Error {
     ExecFailed(io::Error),
     IO(io::Error),
     SystemTime(std::time::SystemTimeError),
-    General(Box<dyn std::error::Error>),
+    General(String),
     Unknown,
 }
 
@@ -142,7 +142,7 @@ impl std::error::Error for Error {
             ExecFailed(ref e) => Some(e),
             IO(ref e) => Some(e),
             SystemTime(ref e) => Some(e),
-            General(ref e) => Some(e.as_ref()),
+            General(_) => None,
             Unknown => None,
         }
     }
@@ -162,7 +162,7 @@ impl From<std::time::SystemTimeError> for Error {
 
 impl From<Box<dyn std::error::Error>> for Error {
     fn from(e: Box<dyn std::error::Error>) -> Error {
-        Error::General(e)
+        Error::General(e.to_string())
     }
 }
 


### PR DESCRIPTION
This minor change achieves two things:

* adds the reason that `kstat_open()` failed, if it did, to the error
* restores the `Send` trait to `sys_info::Error` by removing the boxed `Error` variant (mistakenly added in my prior change), so that it can still be wrapped by the [error-chain](https://crates.io/crates/error-chain) crate as used by [effective-limits](https://crates.io/crates/effective-limits)

With this change in place, I can get `effective-limits` to pass tests on illumos:

```
$ cargo test
   Compiling cc v1.0.50
   Compiling libc v0.2.67
   Compiling sys-info v0.6.1 (/ws/sys-info-rs)
    Finished test [unoptimized + debuginfo] target(s) in 3.96s
     Running target/debug/deps/sys_info-fbc561f55e1cd210

running 9 tests
test test::test_cpu_num ... ok
test test::test_os_release ... ok
test test::test_os_type ... ok
test test::test_hostname ... ok
test test::test_loadavg ... ok
test test::test_proc_total ... ok
test test::test_mem_info ... ok
test test::test_cpu_speed ... ok
test test::test_boottime ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests sys_info

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


$ (cd test && cargo run)
   Compiling sys-info v0.6.1 (/ws/sys-info-rs)
   Compiling test v0.0.1 (/ws/sys-info-rs/test)
    Finished dev [unoptimized + debuginfo] target(s) in 1.95s
     Running `target/debug/test`
os: solaris 5.11
cpu: 16 cores, 2100 MHz
proc total: 60
load: 0.1875 0.1875 0.4140625
mem: total 66990308 KB, free 2902464 KB, avail 0 KB, buffers 0 KB, cached 0 KB
swap: total 0 KB, free 0 KB
hostname: sigma
boottime 8121424 sec, 0 usec


$ cd /var/tmp/effective-limits.rs
$ GIT_PAGER= git diff 
diff --git a/Cargo.toml b/Cargo.toml
index 7940e54..598fdcc 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sys-info = "=0.5.8"
+sys-info = { path = "/ws/sys-info-rs" }
 error-chain = "0.12.2"


$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/debug/deps/effective_limits-79b43257a894680e

running 4 tests
test tests::test_min_opt ... ok
test tests::it_works ... ok
test tests::test_ulimit ... ok
test tests::test_no_ulimit ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/test_limited-b0163b4eebc8395c

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests effective-limits

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```