### PR TITLE
Fix Windows build errors caused by Solaris pathways on v0.6.0

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -229,7 +229,7 @@ pub fn os_release() -> Result<String, Error> {
 /// Gets OS release version on Solaris, returning None if not targeting Solaris
 ///
 /// **Note**: the conditional compilation wrap is needed for the internal imports
-//// to `libc` not causing resolution errors on Windows
+/// to `libc` not causing resolution errors on Windows
 #[cfg(target_os = "solaris")]
 fn solaris_os_release() -> Option<String> {
     unsafe {
@@ -329,7 +329,7 @@ pub fn cpu_num() -> Result<u32, Error> {
 /// Gets the logical CPU count on Solaris, returning None if not targeting Solaris
 ///
 /// **Note**: the conditional compilation wrap is needed for the internal imports
-//// to `libc` not causing resolution errors on Windows
+/// to `libc` not causing resolution errors on Windows
 #[cfg(target_os = "solaris")]
 fn solaris_cpu_num() -> Option<u32> {
     let ret = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
@@ -412,7 +412,7 @@ pub fn loadavg() -> Result<LoadAvg, Error> {
 /// Gets the system average load value. on Solaris, returning None if not targeting Solaris
 ///
 /// **Note**: the conditional compilation wrap is needed for the internal imports
-//// to `libc` not causing resolution errors on Windows
+/// to `libc` not causing resolution errors on Windows
 #[cfg(target_os = "solaris")]
 fn solaris_loadavg() -> Option<LoadAvg> {
     let mut l: [c_double; 3] = [0f64; 3];


### PR DESCRIPTION
### Details

- Fixes the problematic imports in the Solaris paths causing build errors on Windows 10 x64. The problem code was introduced in [`e7e3c0f`](https://github.com/FillZpp/sys-info-rs/commit/e7e3c0f721eae2d6084762bc9ac0ee5656cca187#diff-8c13b5c367b1a0d3dc04da468ea844bdR221).
- Fixes comment in [#50 ](https://github.com/FillZpp/sys-info-rs/issues/50#issuecomment-604451190).
- Uitilizes conditional compilation wrappers to ensure the imports are only compiled for Solaris systems.

#### Build Output (after fix)

![build output](https://i.imgur.com/8YU0IrW.png)

### Note

While I'm not an active contributor of this repository, I agree with the sentiments expressed in the above comment. Since the library is advertised as working on Windows, adding Windows CI to the release process is important because it would stop having versions broken on Windows.

