### PR TITLE
use cfg attribute instead of cfg! macro

### DIFF
--- a/c/macos.c
+++ b/c/macos.c
@@ -80,18 +80,6 @@ unsigned long get_cpu_speed(void) {
 	return speed;
 }
 
-LoadAvg get_loadavg(void) {
-	double loads[3];
-	LoadAvg la;
-	
-	getloadavg(loads, 3);
-	la.one = loads[0];
-	la.five = loads[1];
-	la.fifteen = loads[2];
-	
-	return la;
-}
-
 unsigned long get_proc_total(void) {
 	int mib[3];
 	size_t len;

--- a/kstat.rs
+++ b/kstat.rs
@@ -1,4 +1,4 @@
-#![cfg(target_os = "solaris")]
+#![cfg(any(target_os = "solaris", target_os = "illumos"))]
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -19,8 +19,9 @@ fn main() {
         println!("disk: total {} KB, free {} KB", disk.total, disk.free);
     }
     println!("hostname: {}", hostname().unwrap());
-    let t = boottime().unwrap();
-    println!("boottime {} sec, {} usec", t.tv_sec, t.tv_usec);
-
+    #[cfg(not(target_os = "windows"))] {
+        let t = boottime().unwrap();
+        println!("boottime {} sec, {} usec", t.tv_sec, t.tv_usec);
+    }
 }
 


### PR DESCRIPTION
There are a number of places where we use the cfg! macro today, but
unfortunately though convenient, that pattern does not completely
isolate conditional parts of the build.  This is particularly pertinent
on Windows, which lacks a lot of symbols that ordinarily appear in a
UNIX libc.

This change has been tested on at least:

* Mac OS X
* Windows 10
* Ubuntu 19.10
* illumos

There are no more compilation errors or warnings, and the program in
test/ appears work correctly.