### PR TITLE
Freebsd port improvements

### DIFF
--- a/c/freebsd.c
+++ b/c/freebsd.c
@@ -123,17 +123,16 @@ fail:
 	return (-1);
 }
 
-DiskInfo get_disk_info(void) {
-	DiskInfo di;
+int32_t get_disk_info_freebsd(DiskInfo *di) {
 	struct statfs *sfs, *sf;
 	int i, nmounts;
 	uint64_t dtotal, dfree;
+	int32_t res;
 
-	di.total = 0;
-	di.free = 0;
 	dtotal = 0;
 	dfree = 0;
 	sfs = NULL;
+	res = -1;
 
 	nmounts = getfsstat(NULL, 0, MNT_WAIT);
 	if (nmounts == -1)
@@ -153,10 +152,11 @@ DiskInfo get_disk_info(void) {
 		dfree += sf->f_bfree * sf->f_bsize;
 	}
 
-	di.total = dtotal / 1000;
-	di.free = dfree / 1000;
+	di->total = dtotal / 1000;
+	di->free = dfree / 1000;
+	res = 0;
 
 fail:
 	free(sfs);
-	return (di);
+	return (res);
 }

--- a/c/freebsd.c
+++ b/c/freebsd.c
@@ -33,10 +33,14 @@ uint64_t get_cpu_speed(void) {
 	size_t len;
 	int error;
 
+#if defined(__i386__) || defined(__amd64__)
 	len = sizeof(tsc_freq);
 	error = sysctlbyname("machdep.tsc_freq", &tsc_freq, &len, NULL, 0);
 	if (error == -1)
-		return (1000);
+		return (0);
+#else
+	tsc_freq = 1000 * 1000 * 1000;
+#endif
 	return (tsc_freq / 1000 / 1000);
 }
 

--- a/c/freebsd.c
+++ b/c/freebsd.c
@@ -55,17 +55,17 @@ uint64_t get_proc_total(void) {
 
 	error = sysctl(mib, nitems(mib), NULL, &len, NULL, 0);
 	if (error == -1)
-		return (42);
+		return (0);
 
 	kp = malloc(len);
 	if (kp == NULL)
-		return (42);
+		return (0);
 	memset(kp, 0, len);
 
 	error = sysctl(mib, nitems(mib), kp, &len, NULL, 0);
 	if (error == -1) {
 		free(kp);
-		return (42);
+		return (0);
 	}
 
 	for (count = 0, kpp = kp; (char *)kpp < (char *)kp + len; kpp++) {

--- a/c/freebsd.c
+++ b/c/freebsd.c
@@ -28,7 +28,7 @@ const char *get_os_release(void) {
 	return (os_release);
 }
 
-unsigned long get_cpu_speed(void) {
+uint64_t get_cpu_speed(void) {
 	uint64_t tsc_freq;
 	size_t len;
 	int error;
@@ -40,7 +40,7 @@ unsigned long get_cpu_speed(void) {
 	return (tsc_freq / 1000 / 1000);
 }
 
-unsigned long get_proc_total(void) {
+uint64_t get_proc_total(void) {
 	struct kinfo_proc *kp, *kpp;
 	int mib[3], count, error;
 	size_t len;

--- a/lib.rs
+++ b/lib.rs
@@ -375,9 +375,17 @@ pub fn cpu_speed() -> Result<u64, Error> {
             .map(|speed| speed as u64)
             .ok_or(Error::Unknown)
     }
-    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd"))]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
         unsafe { Ok(get_cpu_speed()) }
+    }
+    #[cfg(any(target_os = "freebsd"))]
+    {
+	let res: u64 = unsafe { get_cpu_speed() };
+	match res {
+	    0 => Err(Error::IO(io::Error::last_os_error())),
+	    _ => Ok(res),
+	}
     }
     #[cfg(not(any(target_os = "solaris", target_os = "illumos", target_os = "linux", target_os = "macos", target_os = "windows", target_os = "freebsd")))]
     {

--- a/lib.rs
+++ b/lib.rs
@@ -453,9 +453,17 @@ pub fn proc_total() -> Result<u64, Error> {
             .and_then(|val| val.parse::<u64>().ok())
             .ok_or(Error::Unknown)
     }
-    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd"))]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     {
         Ok(unsafe { get_proc_total() })
+    }
+    #[cfg(target_os = "freebsd")]
+    {
+	let res: u64 = unsafe { get_proc_total() };
+	match res {
+	    0 => Err(Error::IO(io::Error::last_os_error())),
+	    _ => Ok(res),
+	}
     }
     #[cfg(not(any(target_os = "linux", target_os = "solaris", target_os = "illumos", target_os = "macos", target_os = "windows", target_os = "freebsd")))]
     {

--- a/lib.rs
+++ b/lib.rs
@@ -334,7 +334,7 @@ pub fn cpu_num() -> Result<u32, Error> {
     {
         let ret = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
         if ret < 1 || ret > std::u32::MAX as i64 {
-            Err(Error::Unknown)
+            Err(Error::IO(io::Error::last_os_error()))
         } else {
             Ok(ret as u32)
         }

--- a/lib.rs
+++ b/lib.rs
@@ -242,8 +242,15 @@ pub fn os_release() -> Result<String, Error> {
     }
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd"))]
     {
-        let typ = unsafe { ffi::CStr::from_ptr(get_os_release() as *const c_char).to_bytes() };
-        Ok(String::from_utf8_lossy(typ).into_owned())
+        unsafe {
+	    let rp = get_os_release() as *const c_char;
+	    if rp == std::ptr::null() {
+		Err(Error::Unknown)
+	    } else {
+		let typ = ffi::CStr::from_ptr(rp).to_bytes();
+		Ok(String::from_utf8_lossy(typ).into_owned())
+	    }
+	}
     }
     #[cfg(any(target_os = "solaris", target_os = "illumos"))]
     {


### PR DESCRIPTION
Mostly, these commits systematically return error instead of success with meaningless data for OS failures.  Also they fix small bugs in the port like type mismatch for non-64bit architectures.