### PR TITLE
Add Windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ rust:
   - stable
   - beta
   - nightly
-cache: rust
+cache: cargo
 matrix:
   allow_failures:
     - rust: nightly
+before_script: # Use the msvc toolchain of rust
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then rustup toolchain add $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc && rustup default $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc ; fi
+  # Not auto installed, so add it here 
+  - rustup component add clippy rustfmt && cargo clippy
 script:
   - cargo test --all --verbose
-  - rustup component add clippy rustfmt &&
-    cargo clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ matrix:
     - rust: nightly
 before_script: # Use the msvc toolchain of rust
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then rustup toolchain add $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc && rustup default $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc ; fi
-  # Not auto installed, so add it here 
-  - rustup component add clippy rustfmt
 script:
   - cargo test --all --verbose
-  #- cargo clippy 
+  # Note: Whilst Travis says to install these in the before_script,
+  # on nightly the install command fails
+  # so the install happens after tests so nightly tests are still ran
+  - rustup component add clippy rustfmt
+  - cargo clippy 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ rust:
   - stable
   - beta
   - nightly
-cache: cargo
+cache: rust
 matrix:
   allow_failures:
     - rust: nightly
 before_script: # Use the msvc toolchain of rust
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then rustup toolchain add $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc && rustup default $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc ; fi
   # Not auto installed, so add it here 
-  - rustup component add clippy rustfmt && cargo clippy
+  - rustup component add clippy rustfmt
 script:
   - cargo test --all --verbose
+  #- cargo clippy 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 language: rust
 rust:
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,31 @@ os:
   - linux
   - osx
   - windows
+
 language: rust
 rust:
   - stable
   - beta
   - nightly
-cache: cargo
+
+# Apparently (according to VSCode),
+# `cache: rust` is invalid
+# Should be `cache: cargo`,
+# but this seems to hang the build on windows
+# Uncomment the below line and comment out the current line to enable cargo caching:
+# cache: cargo
+cache: rust
+
 matrix:
   allow_failures:
     - rust: nightly
-before_script: # Use the msvc toolchain of rust
+
+# Use the msvc toolchain of rust on windows
+# The Travis default is _-x86_64-pc-windows-gnu
+# But since we need windows libraries for this crate,
+# _-x86_64-pc-windows-msvc needs to be used instead.
+# See https://github.com/rust-lang/rustup/blob/master/README.md#working-with-rust-on-windows
+before_script:
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then rustup toolchain add $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc && rustup default $TRAVIS_RUST_VERSION-x86_64-pc-windows-msvc ; fi
 script:
   - cargo test --all --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - stable
   - beta
   - nightly
-cache: rust
+cache: cargo
 matrix:
   allow_failures:
     - rust: nightly

--- a/lib.rs
+++ b/lib.rs
@@ -735,7 +735,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(linux)]
+    #[cfg(target_os = "linux")]
     pub fn test_linux_os_release() {
         let os_release = linux_os_release().unwrap();
         println!("linux_os_release(): {:?}", os_release.name)


### PR DESCRIPTION
Over at https://github.com/denoland/deno this crate is used to get info about the system.
As of denoland/deno#4496, one complaint has been that:
> sys-info is broken on Windows for 3 releases now, and doesn't have proper CI.

Therefore, following up on this, I have added a Window CI build to this repo.

Changes:

- Added windows CI build
- Travis' default toolchain is `_-x86_64-pc-windows-gnu`.  This has been swapped for `_-x86_64-pc-windows-msvc` since this crate uses windows headers.  This change has been documented in the CI YAML.
- Changed `#[cfg(linux)]` to `#[cfg(target_os = "linux")]` so `clippy` doesn't complain on rust beta builds
- I was going to change `cache: rust` to `cache: cargo` so cargo stuff can be cached, but this hangs the windows build.  It's a minor thing, however, and so should not block this PR I hope.

NOTE: There's several commits on here to get CI working; I would suggest merging (if you decide to merge) with a squash commit so that the commits I have made don't clutter up the commit history.
