### PR TITLE
Make get_cpu_speed arch-independent on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn main() {
         "darwin" | "ios" => builder.file("c/macos.c"),
         "windows" => {
             println!("cargo:rustc-flags=-l psapi");
+            println!("cargo:rustc-flags=-l Powrprof");
             builder.file("c/windows.c")
         },
 	"freebsd" => {


### PR DESCRIPTION
Instead of guessing the cpu speed based on performance counters query the system for the cpu speed without directly using any intel instructions. Presumably this will also make `get_cpu_speed ` more reliable.

I assume `get_cpu_speed` attempts to get the maximum clock speed because that's what the old version returned for me. If you want, I can add a loop over all the returned results and return the maximum or the value for the current cpu to better support heterogeneous architectures.

closes #68