### PR TITLE
Loop to find max CPU speed in Windows get_cpu_speed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,10 +16,10 @@ fn main() {
         "darwin" | "ios" => builder.file("c/macos.c"),
         "windows" => {
             println!("cargo:rustc-flags=-l psapi");
-            println!("cargo:rustc-flags=-l Powrprof");
+            println!("cargo:rustc-flags=-l powrprof");
             builder.file("c/windows.c")
         },
-	"freebsd" => {
+        "freebsd" => {
             println!("cargo:rustc-flags=-l pthread");
             builder.file("c/freebsd.c")
         },

--- a/c/windows.c
+++ b/c/windows.c
@@ -3,7 +3,6 @@
 #include <string.h>
 #include <windows.h>
 #include <psapi.h>
-#include <winnt.h>
 #include <powerbase.h>
 
 #include "info.h"
@@ -59,14 +58,21 @@ typedef struct _PROCESSOR_POWER_INFORMATION
 	ULONG MhzLimit;
 	ULONG MaxIdleState;
 	ULONG CurrentIdleState;
-} PROCESSOR_POWER_INFORMATION, *PPROCESSOR_POWER_INFORMATION;
+} PROCESSOR_POWER_INFORMATION;
 
 unsigned long get_cpu_speed(void) {
 	unsigned int num = get_cpu_num();
-	PROCESSOR_POWER_INFORMATION *power_info = malloc(num * sizeof(PROCESSOR_POWER_INFORMATION));
+	unsigned int power_info_len = num * sizeof(PROCESSOR_POWER_INFORMATION);
+	PROCESSOR_POWER_INFORMATION *power_info = malloc(power_info_len);
 
-	CallNtPowerInformation(ProcessorInformation, NULL, 0, power_info, num * sizeof(PROCESSOR_POWER_INFORMATION));
-	unsigned int speed = power_info[0].MaxMhz;
+	CallNtPowerInformation(ProcessorInformation, NULL, 0, power_info, power_info_len);
+
+	unsigned int speed = 0;
+	for (unsigned int i = 0; i < num; i++) {
+		if (speed < power_info[i].MaxMhz) {
+			speed = power_info[i].MaxMhz;
+		}
+	}
 
 	free(power_info);
 	return speed;


### PR DESCRIPTION
Great to see that sys-info now compiles correctly on Windows arm64! This would help a lot to make rustup for Windows arm64 happen: https://github.com/rust-lang/rustup/issues/2612

Funnily enough, a few days ago I have prepared exactly the same solution to [make get_cpu_speed arm64-compatible on Windows](https://github.com/Alovchin91/sys-info-rs/commit/327928c3aa9c5925291ee07cd3bd784d9195add3) but I was too slow to open a PR 😅

However, the solution currently in master gives me the wrong result when running `cargo test -- --nocapture` on my Surface Pro X: `cpu_speed(): 1766`.

The reason is ARM's big.LITTLE architecture when the "efficiency" cores are listed first. We need to loop through the CPU cores to find the "actual" maximum CPU speed. Doing this I get the expected result: `cpu_speed(): 2995`.