### PR TITLE
Fix compilation on x86_64-pc-windows-gnu

### DIFF
--- a/c/windows.c
+++ b/c/windows.c
@@ -3,7 +3,9 @@
 #include <string.h>
 #include <windows.h>
 #include <psapi.h>
+#ifndef __GNUC__
 #include <powerbase.h>
+#endif
 
 #include "info.h"
 
@@ -47,6 +49,7 @@ unsigned int get_cpu_num(void) {
 	return num;
 }
 
+#ifndef __GNUC__
 // https://docs.microsoft.com/en-us/windows/win32/power/processor-power-information-str#requirements
 // Note that this structure definition was accidentally omitted from WinNT.h. This error will be corrected in the future.
 // In the meantime, to compile your application, include the structure definition contained in this topic in your source code.
@@ -77,6 +80,7 @@ unsigned long get_cpu_speed(void) {
 	free(power_info);
 	return speed;
 }
+#endif
 
 LoadAvg get_loadavg(void) {
 	FILETIME idle_time, kernel_time, user_time;
@@ -86,7 +90,7 @@ LoadAvg get_loadavg(void) {
 				   file_time_to_ull(kernel_time) +
 				   file_time_to_ull(user_time)) :
 		-1.0;
-	
+
 	la.one = load;
 	la.five = load;
 	la.fifteen = load;
@@ -107,7 +111,7 @@ MemInfo get_mem_info(void) {
 	MEMORYSTATUSEX stat;
 	/* DWORDLONG size; */
 	MemInfo mi;
-	
+
 	stat.dwLength = sizeof(stat);
 	if (GlobalMemoryStatusEx(&stat)) {
 		mi.total = stat.ullTotalPhys / 1024;
@@ -127,7 +131,7 @@ DiskInfo get_disk_info(void) {
 	DWORD cluser, sector, free, total;
 	double tmp;
 	DiskInfo di;
-	
+
 	if (GetDiskFreeSpace(NULL, &cluser, &sector, &free, &total)) {
 		tmp = cluser * sector;
 		di.total = tmp * total / 1024;
@@ -162,7 +166,7 @@ unsigned long long file_time_to_ull(const FILETIME ft) {
 	return (((unsigned long long)(ft.dwHighDateTime)) << 32) |
 		((unsigned long long)ft.dwLowDateTime);
 }
-	
-	
+
+
 
 

--- a/lib.rs
+++ b/lib.rs
@@ -358,7 +358,7 @@ extern "C" {
 
     #[cfg(all(not(any(target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd")), any(unix, windows)))]
     fn get_cpu_num() -> u32;
-    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg(any(target_os = "macos", all(target_os = "windows", not(target_arch = "gnu")), target_os = "freebsd", target_os = "openbsd"))]
     fn get_cpu_speed() -> u64;
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
The `powerbase.h` header can't be found on 64 bit Windows with MingGW, this fix ensures it will still compile, just without the `get_cpu_speed` function.