### PR TITLE
iOS support

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -11,16 +11,16 @@ use std::ffi;
 use std::fmt;
 use std::io::{self, Read};
 use std::fs::File;
-#[cfg(any(target_os = "windows", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "windows", target_vendor = "apple", target_os = "freebsd", target_os = "openbsd"))]
 use std::os::raw::c_char;
 #[cfg(not(any(target_os = "windows", target_os = "linux")))]
 use std::os::raw::{c_int, c_double};
 
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_vendor = "apple", target_os = "freebsd", target_os = "openbsd"))]
 use libc::sysctl;
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_vendor = "apple", target_os = "freebsd", target_os = "openbsd"))]
 use std::mem::size_of_val;
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_vendor = "apple", target_os = "freebsd", target_os = "openbsd"))]
 use std::ptr::null_mut;
 #[cfg(not(target_os = "windows"))]
 use libc::timeval;
@@ -32,9 +32,9 @@ use std::collections::HashMap;
 #[cfg(any(target_os = "solaris", target_os = "illumos"))]
 mod kstat;
 
-#[cfg(any(target_os = "macos", target_os="freebsd", target_os = "openbsd"))]
+#[cfg(any(target_vendor = "apple", target_os="freebsd", target_os = "openbsd"))]
 static OS_CTL_KERN: libc::c_int = 1;
-#[cfg(any(target_os = "macos", target_os="freebsd", target_os = "openbsd"))]
+#[cfg(any(target_vendor = "apple", target_os="freebsd", target_os = "openbsd"))]
 static OS_KERN_BOOTTIME: libc::c_int = 21;
 
 /// System load average value.
@@ -351,27 +351,27 @@ impl From<Box<dyn std::error::Error>> for Error {
 }
 
 extern "C" {
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     fn get_os_type() -> *const i8;
-    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
     fn get_os_release() -> *const i8;
 
     #[cfg(all(not(any(target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd")), any(unix, windows)))]
     fn get_cpu_num() -> u32;
-    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
     fn get_cpu_speed() -> u64;
 
     #[cfg(target_os = "windows")]
     fn get_loadavg() -> LoadAvg;
-    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
     fn get_proc_total() -> u64;
 
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     fn get_mem_info() -> MemInfo;
     #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
     fn get_mem_info_bsd(mi: &mut MemInfo) ->i32;
 
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_vendor = "apple", target_os = "windows"))]
     fn get_disk_info() -> DiskInfo;
     #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
     fn get_disk_info_bsd(di: &mut DiskInfo) -> i32;
@@ -389,7 +389,7 @@ pub fn os_type() -> Result<String, Error> {
         s.pop(); // pop '\n'
         Ok(s)
     }
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     {
         let typ = unsafe { ffi::CStr::from_ptr(get_os_type() as *const c_char).to_bytes() };
         Ok(String::from_utf8_lossy(typ).into_owned())
@@ -410,7 +410,7 @@ pub fn os_type() -> Result<String, Error> {
     {
         Ok("openbsd".to_string())
     }
-    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd")))]
+    #[cfg(not(any(target_os = "linux", target_vendor = "apple", target_os = "windows", target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd")))]
     {
         Err(Error::UnsupportedSystem)
     }
@@ -427,7 +427,7 @@ pub fn os_release() -> Result<String, Error> {
         s.pop(); // pop '\n'
         Ok(s)
     }
-    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd"))]
     {
         unsafe {
 	    let rp = get_os_release() as *const c_char;
@@ -455,7 +455,7 @@ pub fn os_release() -> Result<String, Error> {
             Some(release) => Ok(release),
         }
     }
-    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd")))]
+    #[cfg(not(any(target_os = "linux", target_vendor = "apple", target_os = "windows", target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd")))]
     {
         Err(Error::UnsupportedSystem)
     }
@@ -577,7 +577,7 @@ pub fn cpu_speed() -> Result<u64, Error> {
             .map(|speed| speed as u64)
             .ok_or(Error::Unknown)
     }
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     {
         unsafe { Ok(get_cpu_speed()) }
     }
@@ -589,7 +589,7 @@ pub fn cpu_speed() -> Result<u64, Error> {
 	    _ => Ok(res),
 	}
     }
-    #[cfg(not(any(target_os = "solaris", target_os = "illumos", target_os = "linux", target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
+    #[cfg(not(any(target_os = "solaris", target_os = "illumos", target_os = "linux", target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
     {
         Err(Error::UnsupportedSystem)
     }
@@ -613,7 +613,7 @@ pub fn loadavg() -> Result<LoadAvg, Error> {
             fifteen: loads[2],
         })
     }
-    #[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+    #[cfg(any(target_os = "solaris", target_os = "illumos", target_vendor = "apple", target_os = "freebsd", target_os = "openbsd"))]
     {
         let mut l: [c_double; 3] = [0f64; 3];
         if unsafe { libc::getloadavg(l.as_mut_ptr(), l.len() as c_int) } < 3 {
@@ -630,7 +630,7 @@ pub fn loadavg() -> Result<LoadAvg, Error> {
     {
         Ok(unsafe { get_loadavg() })
     }
-    #[cfg(not(any(target_os = "linux", target_os = "solaris", target_os = "illumos", target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
+    #[cfg(not(any(target_os = "linux", target_os = "solaris", target_os = "illumos", target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
     {
         Err(Error::UnsupportedSystem)
     }
@@ -652,7 +652,7 @@ pub fn proc_total() -> Result<u64, Error> {
             .and_then(|val| val.parse::<u64>().ok())
             .ok_or(Error::Unknown)
     }
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     {
         Ok(unsafe { get_proc_total() })
     }
@@ -664,7 +664,7 @@ pub fn proc_total() -> Result<u64, Error> {
 	    _ => Ok(res),
 	}
     }
-    #[cfg(not(any(target_os = "linux", target_os = "solaris", target_os = "illumos", target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
+    #[cfg(not(any(target_os = "linux", target_os = "solaris", target_os = "illumos", target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
     {
         Err(Error::UnsupportedSystem)
     }
@@ -734,7 +734,7 @@ pub fn mem_info() -> Result<MemInfo, Error> {
             swap_free: 0,
         });
     }
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     {
         Ok(unsafe { get_mem_info() })
     }
@@ -749,7 +749,7 @@ pub fn mem_info() -> Result<MemInfo, Error> {
 	    _ => Err(Error::Unknown),
 	}
     }
-    #[cfg(not(any(target_os = "linux", target_os = "solaris", target_os = "illumos", target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
+    #[cfg(not(any(target_os = "linux", target_os = "solaris", target_os = "illumos", target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
     {
         Err(Error::UnsupportedSystem)
     }
@@ -759,7 +759,7 @@ pub fn mem_info() -> Result<MemInfo, Error> {
 ///
 /// Notice, it just calculate current disk on Windows.
 pub fn disk_info() -> Result<DiskInfo, Error> {
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_vendor = "apple", target_os = "windows"))]
     {
         Ok(unsafe { get_disk_info() })
     }
@@ -773,7 +773,7 @@ pub fn disk_info() -> Result<DiskInfo, Error> {
 	    _ => Err(Error::Unknown),
 	}
     }
-    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
+    #[cfg(not(any(target_os = "linux", target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd")))]
     {
         Err(Error::UnsupportedSystem)
     }
@@ -823,7 +823,7 @@ pub fn boottime() -> Result<timeval, Error> {
         bt.tv_usec = secs[1] as libc::suseconds_t;
 	Ok(bt)
     }
-    #[cfg(any(target_os = "macos", target_os="freebsd", target_os = "openbsd"))]
+    #[cfg(any(target_vendor = "apple", target_os="freebsd", target_os = "openbsd"))]
     {
         let mut mib = [OS_CTL_KERN, OS_KERN_BOOTTIME];
         let mut size: libc::size_t = size_of_val(&bt) as libc::size_t;


### PR DESCRIPTION
`test` binary works on iOS
```
mobile% ./test
os: Darwin 20.2.0
cpu: 6 cores, 25769 MHz
proc total: 279
load: 2.5341796875 2.05908203125 1.86083984375
mem: total 3952272 KB, free 430272 KB, avail 1695056 KB, buffers 0 KB, cached 0 KB
swap: total 262144 KB, free 143872 KB
disk: total 255838461 KB, free 179425959 KB
hostname: iPhone
boottime 1615218195 sec, 202440 usec
```