### PR TITLE
Fix windows-gnu build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,9 +15,13 @@ fn main() {
         }
         "darwin" | "ios" => builder.file("c/macos.c"),
         "windows" => {
+            // GCC linker (ld.exe) wants system libs specified after the source file.
+            // MSVC linker (link.exe) doesn't seem to care.
+            builder.file("c/windows.c")
+                   .compile("info");
             println!("cargo:rustc-flags=-l psapi");
             println!("cargo:rustc-flags=-l powrprof");
-            builder.file("c/windows.c")
+            return;
         },
         "freebsd" => {
             println!("cargo:rustc-flags=-l pthread");

--- a/c/windows.c
+++ b/c/windows.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <windows.h>
 #include <psapi.h>
-#include <powerbase.h>
+#include <powrprof.h>
 
 #include "info.h"
 


### PR DESCRIPTION
This PR fixes sys-info building and linking on windows-gnu targets which prevents integrating the latest version into [effective-limits](https://github.com/rbtcollins/effective-limits.rs/pull/14) which in turn prevents building [rustup for Windows arm64](https://github.com/rust-lang/rustup/issues/2612).