### PR TITLE
Prevent free swap from getting larger than total swap

### DIFF
--- a/c/windows.c
+++ b/c/windows.c
@@ -117,6 +117,9 @@ MemInfo get_mem_info(void) {
 		mi.buffers = 0;
 		mi.swap_total = (stat.ullTotalPageFile - stat.ullTotalPhys) / 1024;
 		mi.swap_free = (stat.ullAvailPageFile - stat.ullAvailPhys) / 1024;
+		if (mi.swap_free > mi.swap_total) {
+			mi.swap_free = mi.swap_total;
+		}
 	} else {
 		memset(&mi, 0, sizeof(mi));
 	}


### PR DESCRIPTION
In some circumstances `swap_free` (zero utilisation?) will end up larger than `swap_total`. To prevent this take the `swap_total` value for `swap_free` if `swap_free` is larger than `swap_total`.
The reason could  be because the `PageFile` and `Phys` values don't quite react the same to new allocations or because the `PageFile` values can either represent process or system level values.