### PR TITLE
Rust Nightly fix

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -825,7 +825,7 @@ pub fn boottime() -> Result<timeval, Error> {
             .collect::<Vec<f64>>();
         bt.tv_sec = secs[0] as libc::time_t;
         bt.tv_usec = secs[1] as libc::suseconds_t;
-	Ok(bt)
+	    return Ok(bt);
     }
     #[cfg(any(target_os = "macos", target_os="freebsd", target_os = "openbsd", target_os = "netbsd"))]
     {
@@ -835,10 +835,10 @@ pub fn boottime() -> Result<timeval, Error> {
             if sysctl(&mut mib[0], 2,
                    &mut bt as *mut timeval as *mut libc::c_void,
                    &mut size, null_mut(), 0) == -1 {
-		Err(Error::IO(io::Error::last_os_error()))
-	    } else {
-		Ok(bt)
-	    }
+                return Err(Error::IO(io::Error::last_os_error()));
+            } else {
+                return Ok(bt);
+            }
         }
     }
     #[cfg(any(target_os = "solaris", target_os = "illumos"))]
@@ -850,7 +850,7 @@ pub fn boottime() -> Result<timeval, Error> {
             return Err(Error::General("time went backwards".into()));
         }
         bt.tv_sec = (now - start) as i64;
-	Ok(bt)
+	    return Ok(bt);
     }
 }
 

--- a/lib.rs
+++ b/lib.rs
@@ -852,9 +852,6 @@ pub fn boottime() -> Result<timeval, Error> {
         bt.tv_sec = (now - start) as i64;
 	    return Ok(bt);
     }
-
-    #[warn(unreachable_code)]
-    Err(Error::UnsupportedSystem)
 }
 
 #[cfg(test)]

--- a/lib.rs
+++ b/lib.rs
@@ -852,6 +852,9 @@ pub fn boottime() -> Result<timeval, Error> {
         bt.tv_sec = (now - start) as i64;
 	    return Ok(bt);
     }
+
+    #[warn(unreachable_code)]
+    Err(Error::UnsupportedSystem)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix for https://github.com/FillZpp/sys-info-rs/issues/98

I've round that implicit `return`s are best when trailing. 