### PR TITLE
Add a cast to allow building on ILP32 systems

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -539,7 +539,7 @@ pub fn cpu_num() -> Result<u32, Error> {
     #[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
     {
         let ret = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
-        if ret < 1 || ret > std::u32::MAX as i64 {
+        if ret < 1 || ret as i64 > std::u32::MAX as i64 {
             Err(Error::IO(io::Error::last_os_error()))
         } else {
             Ok(ret as u32)


### PR DESCRIPTION
On architectures where `c_long` is an `i32`, e.g., OpenBSD/i386, the
comparison between `ret` and `u32::MAX as i64` is a type error.
Add a cast to satisfy the type checker on such architectures. This
cast is a noop on systems where `c_long` is an `i64`.