### PR TITLE
Fix compiler errors/warnings for NetBSD/arm.

### DIFF
--- a/c/netbsd.c
+++ b/c/netbsd.c
@@ -51,10 +51,17 @@ unsigned long get_cpu_speed(void) {
 	error = sysctlbyname("machdep.tsc_freq", &tsc_freq, &len, NULL, 0);
 	if (error == -1)
 		return (0);
-#else
-	uint64_t tsc_freq = ONE_DECIMAL_K * ONE_DECIMAL_K * ONE_DECIMAL_K;
-#endif
 	return (unsigned long) (tsc_freq / ONE_DECIMAL_K / ONE_DECIMAL_K);
+#elif defined(__arm__) || defined(__aarch64__)
+	uint32_t tsc_freq;
+	size_t len = sizeof(tsc_freq);
+	int const result = sysctlbyname("machdep.cpu.frequency.current",
+					&tsc_freq, &len, NULL, 0);
+
+	return result == -1 ? ONE_DECIMAL_K : tsc_freq;
+#else
+	return ONE_DECIMAL_K;
+#endif
 }
 
 unsigned long get_proc_total(void) {


### PR DESCRIPTION
This fixes compilation issues under NetBSD/armv7.

I still can't run the tests, however. I need to link with `libkvm` and I can't figure out how to get `cargo` to include it in the link command. I've made changes to `build.rs` but it never seems to add it to the command line:

```rust
    "netbsd" => {
        println!("cargo:rustc-flags=-l pthread");
        println!("cargo:rustc-flags=-l kvm");
        builder.file("c/netbsd.c")
    }
```

I even tried the example from the Linux branch:

```rust
        println!("cargo:rustc-link-lib=kvm");
```

Any help with this would be appreciated.