### PR TITLE
ffi: use consistent types to improve portability

### DIFF
--- a/c/darwin.c
+++ b/c/darwin.c
@@ -66,7 +66,7 @@ const char *get_os_release(void) {
 	return buf;
 }
 
-unsigned int get_cpu_num(void) {
+uint32_t get_cpu_num(void) {
 	unsigned int num;
 	int mib[2];
 	size_t len;
@@ -81,7 +81,7 @@ unsigned int get_cpu_num(void) {
 	return num;
 }
 
-unsigned long get_cpu_speed(void) {
+uint64_t get_cpu_speed(void) {
 	unsigned long speed;
 	size_t len;
 
@@ -92,7 +92,7 @@ unsigned long get_cpu_speed(void) {
 	return speed;
 }
 
-unsigned long get_proc_total(void) {
+uint64_t get_proc_total(void) {
 	int mib[3];
 	size_t len;
 

--- a/c/freebsd.c
+++ b/c/freebsd.c
@@ -46,7 +46,8 @@ uint64_t get_cpu_speed(void) {
 
 uint64_t get_proc_total(void) {
 	struct kinfo_proc *kp, *kpp;
-	int mib[3], count, error;
+	int mib[3], error;
+	uint64_t count;
 	size_t len;
 
 	mib[0] = CTL_KERN;

--- a/c/info.h
+++ b/c/info.h
@@ -1,6 +1,8 @@
 #ifndef INFO_H_
 #define INFO_H_
 
+#include <stdint.h>
+
 typedef struct LoadAvg {
         double one;
         double five;
@@ -8,30 +10,30 @@ typedef struct LoadAvg {
 } LoadAvg;
 
 typedef struct MemInfo {
-        unsigned long long total;
-        unsigned long long free;
-        unsigned long long avail;
+        uint64_t total;
+        uint64_t free;
+        uint64_t avail;
 
-        unsigned long long buffers;
-        unsigned long long cached;
+        uint64_t buffers;
+        uint64_t cached;
 
-        unsigned long long swap_total;
-        unsigned long long swap_free;
+        uint64_t swap_total;
+        uint64_t swap_free;
 } MemInfo;
 
 typedef struct DiskInfo {
-        unsigned long long total;
-        unsigned long long free;
+        uint64_t total;
+        uint64_t free;
 } DiskInfo;
 
 const char *get_os_type(void);
 const char *get_os_release(void);
 
-unsigned int get_cpu_num(void);
-unsigned long get_cpu_speed(void);
+uint32_t get_cpu_num(void);
+uint64_t get_cpu_speed(void);
 
 LoadAvg get_loadavg(void);
-unsigned long get_proc_total(void);
+uint64_t get_proc_total(void);
 
 MemInfo get_mem_info(void);
 DiskInfo get_disk_info(void);

--- a/c/linux.c
+++ b/c/linux.c
@@ -37,7 +37,7 @@ const char *get_os_release(void) {
 	return "";
 }
 
-unsigned int get_cpu_num(void) {
+uint32_t get_cpu_num(void) {
 	return get_nprocs();
 }
 
@@ -47,7 +47,7 @@ unsigned int get_cpu_num(void) {
   /sys/devices/system/cpu/cpu0
 */
 
-unsigned long get_cpu_speed(void) {
+uint64_t get_cpu_speed(void) {
     return 0;
 }
 
@@ -61,7 +61,7 @@ LoadAvg get_loadavg(void) {
     return avg;
 }
 
-unsigned long get_proc_total(void) {
+uint64_t get_proc_total(void) {
     return 0;
 }
 

--- a/c/netbsd.c
+++ b/c/netbsd.c
@@ -41,7 +41,7 @@ const char *get_os_release(void) {
 	return (os_release);
 }
 
-unsigned long get_cpu_speed(void) {
+uint64_t get_cpu_speed(void) {
 #if defined(__i386__) || defined(__amd64__)
 	uint64_t tsc_freq;
 	size_t len;
@@ -51,7 +51,7 @@ unsigned long get_cpu_speed(void) {
 	error = sysctlbyname("machdep.tsc_freq", &tsc_freq, &len, NULL, 0);
 	if (error == -1)
 		return (0);
-	return (unsigned long) (tsc_freq / ONE_DECIMAL_K / ONE_DECIMAL_K);
+	return (tsc_freq / ONE_DECIMAL_K / ONE_DECIMAL_K);
 #elif defined(__arm__) || defined(__aarch64__)
 	uint32_t tsc_freq;
 	size_t len = sizeof(tsc_freq);
@@ -64,9 +64,9 @@ unsigned long get_cpu_speed(void) {
 #endif
 }
 
-unsigned long get_proc_total(void) {
+uint64_t get_proc_total(void) {
 	char errbuf[_POSIX2_LINE_MAX];
-        int count;
+	int count;
 	kvm_t *kd;
 	struct kinfo_proc *kp;
 
@@ -80,7 +80,7 @@ unsigned long get_proc_total(void) {
 
 	kvm_close(kd);
 	free(kp);
-	return (unsigned long) (count);
+	return (count);
 }
 
 int32_t get_mem_info_bsd(struct MemInfo *mi) {

--- a/c/openbsd.c
+++ b/c/openbsd.c
@@ -28,7 +28,7 @@ const char *get_os_release(void) {
 	return (os_release);
 }
 
-unsigned long get_cpu_speed(void) {
+uint64_t get_cpu_speed(void) {
 	unsigned int mhz;
 	int mib[2], error;
 	size_t len;
@@ -43,7 +43,7 @@ unsigned long get_cpu_speed(void) {
 	return mhz;
 }
 
-unsigned long get_proc_total(void) {
+uint64_t get_proc_total(void) {
 	struct kinfo_proc *kp, *kpp;
 	int mib[6], count, error;
 	size_t len;

--- a/c/test.c
+++ b/c/test.c
@@ -5,22 +5,26 @@ int main(void) {
 	printf("os type: %s\n", get_os_type());
 	printf("os release: %s\n", get_os_release());
 
-	printf("\ncpu num: %u\n", get_cpu_num());
-	printf("cpu speed: %lu\n", get_cpu_speed());
+	printf("\ncpu num: %u\n", (unsigned int) get_cpu_num());
+	printf("cpu speed: %lu\n", (unsigned long) get_cpu_speed());
 
 	LoadAvg la = get_loadavg();
 	printf("\nloadavg: %f %f %f\n", la.one, la.five, la.fifteen);
 
-	printf("proc total: %lu\n", get_proc_total());
+	printf("proc total: %lu\n", (unsigned long) get_proc_total());
 
 	MemInfo mi = get_mem_info();
 	printf("\nmem:\ntotal %llu, avail %llu, free %llu\n",
-	     mi.total, mi.avail, mi.free);
-	printf("buffers %llu, cached %llu\n", mi.buffers, mi.cached);
-	printf("swap: total %llu, free %llu\n", mi.swap_total, mi.swap_free);
+		(unsigned long long) mi.total, (unsigned long long) mi.avail,
+		(unsigned long long) mi.free);
+	printf("buffers %llu, cached %llu\n",
+		(unsigned long long) mi.buffers, (unsigned long long) mi.cached);
+	printf("swap: total %llu, free %llu\n",
+		(unsigned long long) mi.swap_total, (unsigned long long) mi.swap_free);
 
 	DiskInfo di = get_disk_info();
-	printf("\ndisk: total %llu, free %llu\n", di.total, di.free);
+	printf("\ndisk: total %llu, free %llu\n",
+		(unsigned long long) di.total, (unsigned long long) di.free);
 
 	return 0;
 }

--- a/c/windows.c
+++ b/c/windows.c
@@ -37,7 +37,7 @@ const char *get_os_release(void) {
 	return s;
 }
 
-unsigned int get_cpu_num(void) {
+uint32_t get_cpu_num(void) {
 	unsigned int num;
 	SYSTEM_INFO sys_info;
 
@@ -60,14 +60,17 @@ typedef struct _PROCESSOR_POWER_INFORMATION
 	ULONG CurrentIdleState;
 } PROCESSOR_POWER_INFORMATION;
 
-unsigned long get_cpu_speed(void) {
-	unsigned int num = get_cpu_num();
-	unsigned int power_info_len = num * sizeof(PROCESSOR_POWER_INFORMATION);
+uint64_t get_cpu_speed(void) {
+	uint32_t num = get_cpu_num();
+	size_t power_info_len = num * sizeof(PROCESSOR_POWER_INFORMATION);
 	PROCESSOR_POWER_INFORMATION *power_info = malloc(power_info_len);
+	if (power_info == NULL)	{
+		return 0;
+	}
 
 	CallNtPowerInformation(ProcessorInformation, NULL, 0, power_info, power_info_len);
 
-	unsigned int speed = 0;
+	ULONG speed = 0;
 	for (unsigned int i = 0; i < num; i++) {
 		if (speed < power_info[i].MaxMhz) {
 			speed = power_info[i].MaxMhz;
@@ -93,13 +96,13 @@ LoadAvg get_loadavg(void) {
 	return la;
 }
 
-unsigned long get_proc_total(void) {
+uint64_t get_proc_total(void) {
 	DWORD aprocesses[MAXPROCESSES], cb_needed, cprocesses;
 
 	if (!EnumProcesses(aprocesses, sizeof(aprocesses), &cb_needed))
 		cprocesses = 0;
 	else
-		cprocesses = cb_needed / sizeof(unsigned long);
+		cprocesses = cb_needed / sizeof(DWORD);
 	return cprocesses;
 }
 

--- a/lib.rs
+++ b/lib.rs
@@ -352,9 +352,9 @@ impl From<Box<dyn std::error::Error>> for Error {
 
 extern "C" {
     #[cfg(any(target_vendor = "apple", target_os = "windows"))]
-    fn get_os_type() -> *const i8;
+    fn get_os_type() -> *const c_char;
     #[cfg(any(target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
-    fn get_os_release() -> *const i8;
+    fn get_os_release() -> *const c_char;
 
     #[cfg(all(not(any(target_os = "solaris", target_os = "illumos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd")), any(unix, windows)))]
     fn get_cpu_num() -> u32;
@@ -369,7 +369,7 @@ extern "C" {
     #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     fn get_mem_info() -> MemInfo;
     #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
-    fn get_mem_info_bsd(mi: &mut MemInfo) ->i32;
+    fn get_mem_info_bsd(mi: &mut MemInfo) -> i32;
 
     #[cfg(any(target_os = "linux", target_vendor = "apple", target_os = "windows"))]
     fn get_disk_info() -> DiskInfo;
@@ -391,7 +391,7 @@ pub fn os_type() -> Result<String, Error> {
     }
     #[cfg(any(target_vendor = "apple", target_os = "windows"))]
     {
-        let typ = unsafe { ffi::CStr::from_ptr(get_os_type() as *const c_char).to_bytes() };
+        let typ = unsafe { ffi::CStr::from_ptr(get_os_type()).to_bytes() };
         Ok(String::from_utf8_lossy(typ).into_owned())
     }
     #[cfg(target_os = "solaris")]
@@ -434,7 +434,7 @@ pub fn os_release() -> Result<String, Error> {
     #[cfg(any(target_vendor = "apple", target_os = "windows", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
     {
         unsafe {
-	    let rp = get_os_release() as *const c_char;
+	    let rp = get_os_release();
 	    if rp == std::ptr::null() {
 		Err(Error::Unknown)
 	    } else {


### PR DESCRIPTION
Also fixes potential crash in windows get_cpu_speed().