### PR TITLE
Suppress unreachable_code lint

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -853,7 +853,7 @@ pub fn boottime() -> Result<timeval, Error> {
 	    return Ok(bt);
     }
 
-    #[warn(unreachable_code)]
+    #[allow(unreachable_code)]
     Err(Error::UnsupportedSystem)
 }
 


### PR DESCRIPTION
Beforehand, this has the opposite of the desired behavior. Instead of
causing a warning on *unsupported* platforms, this only emits an error
on *supported* platforms.

As of writing, there is no `compiler_warning!` macro like there is
`compile_error!` in std.

Resolves #103.