### PR TITLE
netbsd: link to libkvm to fix build error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,7 @@ fn main() {
             builder.file("c/openbsd.c")
         },
         "netbsd" => {
+            println!("cargo:rustc-flags=-l kvm");
             println!("cargo:rustc-flags=-l pthread");
             builder.file("c/netbsd.c")
         },


### PR DESCRIPTION
NetBSD requires linking to the libkvm library to use functions like　`kvm_openfiles()`.

Otherwise, you get a link error like:
```
  = note: ld: /home/user/sys-info-rs/target/debug/build/sys-info-296322ef26a55e63/out/libinfo.a(netbsd.o): in function `get_proc_total':
          /home/user/sys-info-rs/c/netbsd.c:73: undefined reference to `kvm_openfiles'                        
          ld: /home/user//sys-info-rs/c/netbsd.c:76: undefined reference to `kvm_getprocs'                     
          ld: /home/user/sys-info-rs/c/netbsd.c:77: undefined reference to `kvm_close'                        
          ld: /home/usersys-info-rs/c/netbsd.c:81: undefined reference to `kvm_close'                        
                                                                                                                      
  = help: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link                                                       

```